### PR TITLE
Fix the Ingress configuration in Wordpress manifest

### DIFF
--- a/manifests/wordpress/wp.yaml
+++ b/manifests/wordpress/wp.yaml
@@ -40,19 +40,23 @@ spec:
   selector:
     app: wordpress
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wordpress
   namespace: wordpress
 spec:
   rules:
-  - host: wordpress.192.168.99.100.nip.io
-    http:
-      paths:
-      - backend:
-          serviceName: wordpress
-          servicePort: 80
+    - host: wordpress.local.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wordpress
+                port:
+                  number: 80
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -78,6 +82,8 @@ spec:
         env:
         - name: MYSQL_ROOT_PASSWORD
           value: root
+        - name: MYSQL_DATABASE
+          value: wordpress
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -101,7 +107,11 @@ spec:
         ports:
         - containerPort: 80
         env:
+        - name: WORDPRESS_DB_USER
+          value: root
         - name: WORDPRESS_DB_PASSWORD
           value: root
         - name: WORDPRESS_DB_HOST
           value: mysql
+        - name: WORDPRESS_DB_NAME
+          value: wordpress

--- a/manifests/wordpress/wp.yaml
+++ b/manifests/wordpress/wp.yaml
@@ -47,7 +47,7 @@ metadata:
   namespace: wordpress
 spec:
   rules:
-    - host: wordpress.local.io
+    - host: wordpress.192.168.99.100.nip.io
       http:
         paths:
           - path: /


### PR DESCRIPTION
Hi, the configuration in wp.yaml didn't work, the Ingress is already out of beta and requires a slightly different configuration and the wordpress container seemed to require some additional environment variables to get pass through DB connection error.